### PR TITLE
fix for AKS deployment

### DIFF
--- a/deploy/aks-deployment.yml
+++ b/deploy/aks-deployment.yml
@@ -47,17 +47,6 @@ spec:
       labels:
         app: elasticsearch
     spec:
-      initContainers:
-        - name: init-elasticsearch
-          image: busybox:1.28
-          command: ["/bin/sh", "-c"]
-          args:
-            - chown -R 1000:1000 /usr/share/elasticsearch/data && chown -R 1000:1000 /usr/share/elasticsearch/logs
-          volumeMounts:
-            - name: elasticsearch
-              mountPath: /usr/share/elasticsearch/data
-            - name: elasticsearch
-              mountPath: /usr/share/elasticsearch/logs
       containers:
         - name: elasticsearch
           image: ghcr.io/satomic/copilot-usage-advanced-dashboard/elastic-search:main
@@ -122,24 +111,6 @@ spec:
       labels:
         app: grafana
     spec:
-      initContainers:
-        - name: update-grafana
-          image: ghcr.io/satomic/copilot-usage-advanced-dashboard/grafana-updater:main
-          envFrom:
-            - secretRef:
-                name: grafana-credentials
-          env:
-            - name: ELASTICSEARCH_URL
-              value: "http://elasticsearch:9200"
-            - name: GRAFANA_URL
-              value: "http://grafana:80"
-          resources:
-            requests:
-              cpu: "0.25"
-              memory: "256Mi"
-            limits:
-              cpu: "0.5"
-              memory: "512Mi"
       containers:
         - name: grafana
           image: ghcr.io/satomic/copilot-usage-advanced-dashboard/grafana:main
@@ -178,13 +149,14 @@ spec:
             httpGet:
               path: /api/health
               port: 80
-            initialDelaySeconds: 30
-            periodSeconds: 10
+            initialDelaySeconds: 90
+            periodSeconds: 30
+            failureThreshold: 5
           readinessProbe:
             httpGet:
               path: /api/health
               port: 80
-            initialDelaySeconds: 10
+            initialDelaySeconds: 30
             periodSeconds: 10
       volumes:
         - name: grafana-data
@@ -263,3 +235,32 @@ spec:
             - name: cpuad-updater-logs
               persistentVolumeClaim:
                 claimName: shared-pvc
+
+# --- update-grafana Job (runs once) ---
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: update-grafana-once
+spec:
+  template:
+    spec:
+      containers:
+        - name: update-grafana
+          image: ghcr.io/satomic/copilot-usage-advanced-dashboard/grafana-updater:main
+          envFrom:
+            - secretRef:
+                name: grafana-credentials
+          env:
+            - name: ELASTICSEARCH_URL
+              value: "http://elasticsearch:9200"
+            - name: GRAFANA_URL
+              value: "http://grafana:80"
+          resources:
+            requests:
+              cpu: "0.25"
+              memory: "256Mi"
+            limits:
+              cpu: "0.5"
+              memory: "512Mi"
+      restartPolicy: Never


### PR DESCRIPTION
This pull request refactors the `deploy/aks-deployment.yml` file to simplify the deployment configuration by removing redundant `initContainers` and introducing a one-time `Job` for Grafana updates. It also adjusts the liveness and readiness probe configurations to improve application stability.

### Deployment Configuration Simplifications:
* Removed the `initContainers` for Elasticsearch that were responsible for setting permissions on data and log directories, as they are no longer necessary. (`[deploy/aks-deployment.ymlL50-L60](diffhunk://#diff-1d5f3dd3b84ca8c9e0146f31ba023e12ad6ddf8991197eda44431bf82048eb76L50-L60)`)
* Removed the `initContainers` for Grafana that updated the configuration during deployment, simplifying the deployment spec. (`[deploy/aks-deployment.ymlL125-L142](diffhunk://#diff-1d5f3dd3b84ca8c9e0146f31ba023e12ad6ddf8991197eda44431bf82048eb76L125-L142)`)

### Stability Improvements:
* Updated liveness and readiness probe parameters for Grafana to increase the initial delay and adjust the probing intervals, enhancing application stability during startup. (`[deploy/aks-deployment.ymlL181-R159](diffhunk://#diff-1d5f3dd3b84ca8c9e0146f31ba023e12ad6ddf8991197eda44431bf82048eb76L181-R159)`)

### New Feature:
* Introduced a one-time `Job` named `update-grafana-once` to handle Grafana updates independently of the deployment process, ensuring better separation of concerns. (`[deploy/aks-deployment.ymlR238-R266](diffhunk://#diff-1d5f3dd3b84ca8c9e0146f31ba023e12ad6ddf8991197eda44431bf82048eb76R238-R266)`)